### PR TITLE
Refactor with modular imports

### DIFF
--- a/events.js
+++ b/events.js
@@ -1,0 +1,190 @@
+export function setupEventListeners(ui, handlers) {
+    const {
+        canvas,
+        debugToggle,
+        resetBtn,
+        exportBtn,
+        importFile,
+        toggleModeBtn,
+        toggleHeaderBtn,
+        resetViewBtn,
+        addTokenBtn,
+        clearTokensBtn,
+        loadUrlBtn,
+        mapUrlInput,
+        hexSizeInput,
+        offsetXInput,
+        offsetYInput,
+        columnsInput,
+        rowsInput,
+        mapScaleInput,
+        fogColorInput,
+        fogOpacityInput,
+        gridColorInput,
+        gridThicknessInput,
+        tokenColorInput,
+        exportModal,
+        exportModalClose,
+        exportJsonTextarea,
+        copyJsonBtn,
+        downloadJsonBtn
+    } = ui;
+
+    const {
+        handleCanvasClick,
+        handleZoom,
+        startPanning,
+        stopPanning,
+        handleMouseMove,
+        validateInput,
+        loadMap,
+        generateHexGrid,
+        drawMap,
+        saveState,
+        toggleMode,
+        toggleHeader,
+        resetMap,
+        resetView,
+        toggleAddTokenMode,
+        clearTokens,
+        handleExport,
+        handleImport
+    } = handlers;
+
+    canvas.addEventListener('click', handleCanvasClick);
+    hexSizeInput.addEventListener('change', function() {
+        handlers.state.hexSize = validateInput(this, 10, 300, 40);
+        generateHexGrid();
+        drawMap();
+        saveState();
+    });
+    offsetXInput.addEventListener('change', function() {
+        handlers.state.offsetX = validateInput(this, -1000, 1000, 0);
+        generateHexGrid();
+        drawMap();
+        saveState();
+    });
+    offsetYInput.addEventListener('change', function() {
+        handlers.state.offsetY = validateInput(this, -1000, 1000, 0);
+        generateHexGrid();
+        drawMap();
+        saveState();
+    });
+    columnsInput.addEventListener('change', function() {
+        handlers.state.columnCount = validateInput(this, 1, 200, 20);
+        generateHexGrid();
+        drawMap();
+        saveState();
+    });
+    rowsInput.addEventListener('change', function() {
+        handlers.state.rowCount = validateInput(this, 1, 200, 15);
+        generateHexGrid();
+        drawMap();
+        saveState();
+    });
+    mapScaleInput.addEventListener('change', function() {
+        handlers.state.mapScale = validateInput(this, 10, 500, 100);
+        drawMap();
+        saveState();
+    });
+    fogColorInput.addEventListener('change', function() {
+        handlers.state.fogColor = this.value;
+        drawMap();
+        saveState();
+    });
+    fogOpacityInput.addEventListener('input', function() {
+        handlers.state.fogOpacity = parseFloat(this.value);
+        drawMap();
+        saveState();
+    });
+    gridColorInput.addEventListener('change', function() {
+        handlers.state.gridColor = this.value;
+        drawMap();
+        saveState();
+    });
+    gridThicknessInput.addEventListener('input', function() {
+        handlers.state.gridThickness = parseFloat(this.value);
+        drawMap();
+        saveState();
+    });
+    tokenColorInput.addEventListener('change', function() {
+        handlers.state.tokenColor = this.value;
+        drawMap();
+        saveState();
+    });
+
+    toggleModeBtn.addEventListener('click', toggleMode);
+    toggleHeaderBtn.addEventListener('click', toggleHeader);
+    resetBtn.addEventListener('click', resetMap);
+    resetViewBtn.addEventListener('click', resetView);
+    addTokenBtn.addEventListener('click', toggleAddTokenMode);
+    clearTokensBtn.addEventListener('click', clearTokens);
+
+    loadUrlBtn.addEventListener('click', function() {
+        const url = mapUrlInput.value.trim();
+        if (!url) return;
+        loadMap(url);
+    });
+    mapUrlInput.addEventListener('input', function() {
+        const url = mapUrlInput.value.trim();
+        if (!url) {
+            mapUrlInput.classList.remove('invalid-input');
+        } else if (/^https?:\/\//.test(url)) {
+            mapUrlInput.classList.remove('invalid-input');
+        } else {
+            mapUrlInput.classList.add('invalid-input');
+        }
+    });
+    mapUrlInput.addEventListener('keypress', function(e) {
+        if (e.key === 'Enter') loadUrlBtn.click();
+    });
+
+    canvas.addEventListener('wheel', handleZoom);
+    canvas.addEventListener('mousedown', startPanning);
+    canvas.addEventListener('mousemove', handleMouseMove);
+    canvas.addEventListener('mouseup', stopPanning);
+    canvas.addEventListener('mouseleave', stopPanning);
+    canvas.addEventListener('contextmenu', e => e.preventDefault());
+
+    window.addEventListener('resize', drawMap);
+    debugToggle.addEventListener('click', function() {
+        handlers.state.debugMode = !handlers.state.debugMode;
+        ui.debugInfo.style.display = handlers.state.debugMode ? 'block' : 'none';
+        drawMap();
+    });
+    exportBtn.addEventListener('click', handleExport);
+    exportModalClose.addEventListener('click', () => { exportModal.style.display = 'none'; });
+    copyJsonBtn.addEventListener('click', () => { exportJsonTextarea.select(); navigator.clipboard.writeText(exportJsonTextarea.value); });
+    downloadJsonBtn.addEventListener('click', () => {
+        const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(exportJsonTextarea.value);
+        const a = document.createElement('a');
+        a.setAttribute('href', dataStr);
+        a.setAttribute('download', 'hex-map-state.json');
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+    });
+    importFile.addEventListener('change', handleImport);
+    window.addEventListener('click', function(event) {
+        if (event.target === exportModal) exportModal.style.display = 'none';
+    });
+    document.addEventListener('keydown', function(event) {
+        if (event.ctrlKey && event.key === 'e') { event.preventDefault(); handleExport(); }
+        if (event.ctrlKey && event.key === 'i') { event.preventDefault(); importFile.click(); }
+        if (event.ctrlKey && event.key === 'm') { event.preventDefault(); toggleMode(); }
+        if (event.ctrlKey && event.key === 't') { event.preventDefault(); toggleAddTokenMode(); }
+        if (event.key === 'Escape') {
+            if (handlers.state.isAddingToken) { toggleAddTokenMode(); }
+            else if (handlers.state.selectedTokenIndex !== -1) {
+                handlers.state.selectedTokenIndex = -1;
+                drawMap();
+            }
+        }
+        if (event.key === 'Delete' && handlers.state.selectedTokenIndex !== -1) {
+            handlers.state.tokens.splice(handlers.state.selectedTokenIndex, 1);
+            handlers.state.selectedTokenIndex = -1;
+            drawMap();
+            saveState();
+        }
+    });
+}

--- a/index.html
+++ b/index.html
@@ -124,6 +124,9 @@
   </div>
 </div>
 <!-- partial -->
+  <script type="module" src="./state.js"></script>
+  <script type="module" src="./render.js"></script>
+  <script type="module" src="./events.js"></script>
   <script type="module" src="./script.js"></script>
 
 </body>

--- a/render.js
+++ b/render.js
@@ -1,0 +1,164 @@
+import { state } from './state.js';
+
+export function generateHexGrid() {
+    state.hexes = [];
+    const hexWidth = state.hexSize * Math.sqrt(3);
+    const hexHeight = state.hexSize * 2;
+    for (let row = 0; row < state.rowCount; row++) {
+        for (let col = 0; col < state.columnCount; col++) {
+            const x = col * hexWidth + (row % 2 === 1 ? hexWidth / 2 : 0) + state.offsetX;
+            const y = row * (hexHeight * 3 / 4) + state.offsetY;
+            const hexId = `${col}-${row}`;
+            const isRevealed = state.revealedHexes[hexId] === true;
+            const vertices = [];
+            for (let i = 0; i < 6; i++) {
+                const angle = (Math.PI / 3) * i + Math.PI / 2;
+                const px = x + state.hexSize * Math.cos(angle);
+                const py = y + state.hexSize * Math.sin(angle);
+                vertices.push({ x: px, y: py });
+            }
+            state.hexes.push({ id: hexId, x, y, row, col, revealed: isRevealed, vertices });
+        }
+    }
+}
+
+export function drawHex(ctx, hex) {
+    ctx.beginPath();
+    const vertices = hex.vertices;
+    ctx.moveTo(vertices[0].x, vertices[0].y);
+    for (let i = 1; i < 6; i++) {
+        ctx.lineTo(vertices[i].x, vertices[i].y);
+    }
+    ctx.closePath();
+    if (state.debugMode) {
+        ctx.fillStyle = 'red';
+        ctx.beginPath();
+        ctx.arc(hex.x, hex.y, 3, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.fillStyle = 'white';
+        ctx.font = '10px Arial';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(hex.id, hex.x, hex.y);
+        ctx.fillStyle = 'yellow';
+        for (let vertex of vertices) {
+            ctx.beginPath();
+            ctx.arc(vertex.x, vertex.y, 2, 0, Math.PI * 2);
+            ctx.fill();
+        }
+    }
+}
+
+export function drawMap(ctx, canvas, ui) {
+    if (!ctx || !state.mapImage) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.save();
+    ctx.translate(state.panX, state.panY);
+    ctx.scale(state.zoomLevel, state.zoomLevel);
+    const scaleRatio = state.mapScale / 100;
+    const scaledWidth = state.mapImage.width * scaleRatio;
+    const scaledHeight = state.mapImage.height * scaleRatio;
+    ctx.drawImage(state.mapImage, 0, 0, state.mapImage.width, state.mapImage.height, 0, 0, scaledWidth, scaledHeight);
+    ctx.strokeStyle = state.gridColor;
+    ctx.lineWidth = state.gridThickness;
+    ctx.fillStyle = `${state.fogColor}${Math.round(state.fogOpacity * 255).toString(16).padStart(2, '0')}`;
+    for (const hex of state.hexes) {
+        if (!hex.revealed) {
+            drawHex(ctx, hex);
+            ctx.fill();
+            ctx.stroke();
+        } else if (state.debugMode) {
+            ctx.save();
+            ctx.strokeStyle = 'yellow';
+            ctx.lineWidth = 2;
+            ctx.setLineDash([5, 5]);
+            drawHex(ctx, hex);
+            ctx.stroke();
+            ctx.restore();
+        }
+    }
+    for (let i = 0; i < state.tokens.length; i++) {
+        const token = state.tokens[i];
+        const isSelected = i === state.selectedTokenIndex;
+        ctx.beginPath();
+        ctx.arc(token.x, token.y, state.hexSize * 0.4, 0, Math.PI * 2);
+        ctx.fillStyle = token.color || state.tokenColor;
+        ctx.fill();
+        if (isSelected) {
+            ctx.strokeStyle = 'white';
+            ctx.lineWidth = 3;
+            ctx.stroke();
+        } else {
+            ctx.strokeStyle = 'black';
+            ctx.lineWidth = 1;
+            ctx.stroke();
+        }
+    }
+    if (state.debugMode) {
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+        ctx.fillRect(10, 10, 200, 100);
+        ctx.fillStyle = 'white';
+        ctx.font = '12px Arial';
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+        ctx.fillText(`Total Hexes: ${state.hexes.length}`, 20, 20);
+        ctx.fillText(`Revealed: ${Object.keys(state.revealedHexes).length}`, 20, 40);
+        ctx.fillText(`Mode: ${state.revealMode ? 'Reveal' : 'Hide'}`, 20, 60);
+        ctx.fillText(`Zoom: ${(state.zoomLevel * 100).toFixed(0)}%`, 20, 80);
+    }
+    ctx.restore();
+    updateZoomDisplay(ui);
+}
+
+export function updateZoomDisplay(ui) {
+    if (ui && ui.zoomDisplay) {
+        ui.zoomDisplay.textContent = `Zoom: ${Math.round(state.zoomLevel * 100)}%`;
+    }
+}
+
+export function updateCoordDisplay(ui, hex) {
+    if (ui && ui.coordDisplay) {
+        if (hex) {
+            ui.coordDisplay.textContent = `Hex: ${hex.col},${hex.row}`;
+        } else {
+            ui.coordDisplay.textContent = 'Hex: ---';
+        }
+    }
+}
+
+export function isPointInHex(px, py, hex) {
+    const adjustedX = (px - state.panX) / state.zoomLevel;
+    const adjustedY = (py - state.panY) / state.zoomLevel;
+    const vertices = hex.vertices;
+    let inside = false;
+    for (let i = 0, j = vertices.length - 1; i < vertices.length; j = i++) {
+        const xi = vertices[i].x, yi = vertices[i].y;
+        const xj = vertices[j].x, yj = vertices[j].y;
+        const intersect = ((yi > adjustedY) !== (yj > adjustedY)) &&
+            (adjustedX < (xj - xi) * (adjustedY - yi) / (yj - yi) + xi);
+        if (intersect) inside = !inside;
+    }
+    return inside;
+}
+
+export function findTokenAtPosition(x, y) {
+    const adjustedX = (x - state.panX) / state.zoomLevel;
+    const adjustedY = (y - state.panY) / state.zoomLevel;
+    for (let i = state.tokens.length - 1; i >= 0; i--) {
+        const token = state.tokens[i];
+        const dx = token.x - adjustedX;
+        const dy = token.y - adjustedY;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        if (distance <= state.hexSize * 0.4) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+export function getCanvasCoords(event, canvas) {
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    return { x: (event.clientX - rect.left) * scaleX, y: (event.clientY - rect.top) * scaleY };
+}

--- a/state.js
+++ b/state.js
@@ -1,0 +1,115 @@
+export const STORAGE_KEY = 'pointyTopHexMapState';
+
+export const state = {
+    hexSize: 40,
+    offsetX: 0,
+    offsetY: 0,
+    columnCount: 20,
+    rowCount: 15,
+    mapScale: 100,
+    hexes: [],
+    revealedHexes: {},
+    mapImage: null,
+    zoomLevel: 1,
+    panX: 0,
+    panY: 0,
+    isPanning: false,
+    lastMouseX: 0,
+    lastMouseY: 0,
+    fogColor: '#225522',
+    fogOpacity: 0.85,
+    gridColor: '#FFFFFF',
+    gridThickness: 1,
+    tokenColor: '#FF0000',
+    tokens: [],
+    isDraggingToken: false,
+    selectedTokenIndex: -1,
+    isAddingToken: false,
+    revealMode: true,
+    debugMode: false
+};
+
+export function loadSavedState(ui) {
+    try {
+        const savedState = localStorage.getItem(STORAGE_KEY);
+        if (!savedState) return;
+        const data = JSON.parse(savedState);
+        state.revealedHexes = data.revealedHexes || {};
+        if (data.settings) {
+            state.hexSize = data.settings.hexSize || state.hexSize;
+            state.offsetX = data.settings.offsetX || state.offsetX;
+            state.offsetY = data.settings.offsetY || state.offsetY;
+            state.columnCount = data.settings.columnCount || state.columnCount;
+            state.rowCount = data.settings.rowCount || state.rowCount;
+            state.mapScale = data.settings.mapScale || state.mapScale;
+            state.fogColor = data.settings.fogColor || state.fogColor;
+            state.fogOpacity = data.settings.fogOpacity || state.fogOpacity;
+            state.gridColor = data.settings.gridColor || state.gridColor;
+            state.gridThickness = data.settings.gridThickness || state.gridThickness;
+            state.tokenColor = data.settings.tokenColor || state.tokenColor;
+
+            if (ui) {
+                ui.hexSizeInput.value = state.hexSize;
+                ui.offsetXInput.value = state.offsetX;
+                ui.offsetYInput.value = state.offsetY;
+                ui.columnsInput.value = state.columnCount;
+                ui.rowsInput.value = state.rowCount;
+                ui.mapScaleInput.value = state.mapScale;
+                ui.fogColorInput.value = state.fogColor;
+                ui.fogOpacityInput.value = state.fogOpacity;
+                ui.gridColorInput.value = state.gridColor;
+                ui.gridThicknessInput.value = state.gridThickness;
+                ui.tokenColorInput.value = state.tokenColor;
+            }
+        }
+        if (data.tokens) {
+            state.tokens = data.tokens;
+        }
+    } catch (err) {
+        console.error('Error loading saved state:', err);
+    }
+}
+
+export function updateSavedState(key, value) {
+    try {
+        let saved = {};
+        const current = localStorage.getItem(STORAGE_KEY);
+        if (current) saved = JSON.parse(current);
+        saved[key] = value;
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(saved));
+    } catch (err) {
+        console.error('Error updating saved state:', err);
+    }
+}
+
+export function saveState(ui) {
+    try {
+        const settings = {
+            hexSize: state.hexSize,
+            offsetX: state.offsetX,
+            offsetY: state.offsetY,
+            columnCount: state.columnCount,
+            rowCount: state.rowCount,
+            mapScale: state.mapScale,
+            fogColor: state.fogColor,
+            fogOpacity: state.fogOpacity,
+            gridColor: state.gridColor,
+            gridThickness: state.gridThickness,
+            tokenColor: state.tokenColor
+        };
+        const view = {
+            zoomLevel: state.zoomLevel,
+            panX: state.panX,
+            panY: state.panY
+        };
+        updateSavedState('revealedHexes', state.revealedHexes);
+        updateSavedState('settings', settings);
+        updateSavedState('tokens', state.tokens);
+        updateSavedState('view', view);
+        if (ui && ui.mapUrlInput && ui.mapUrlInput.value.trim()) {
+            updateSavedState('mapUrl', ui.mapUrlInput.value);
+        }
+    } catch (err) {
+        console.error('Error saving state:', err);
+    }
+}


### PR DESCRIPTION
## Summary
- add `state.js` with persistence helpers
- add `render.js` for drawing routines
- add `events.js` to group event listener setup
- reference new modules from `index.html`

## Testing
- `node --check state.js`
- `node --check render.js`
- `node --check events.js`

------
https://chatgpt.com/codex/tasks/task_e_6871e40811d8832f887cd21eef951c57