### PR TITLE
Fix fog color alpha handling

### DIFF
--- a/render.js
+++ b/render.js
@@ -1,5 +1,18 @@
 import { state } from './state.js';
 
+function hexToRgb(hex) {
+    hex = hex.replace('#', '');
+    if (hex.length === 3) {
+        hex = hex.split('').map(c => c + c).join('');
+    }
+    const num = parseInt(hex, 16);
+    return {
+        r: (num >> 16) & 255,
+        g: (num >> 8) & 255,
+        b: num & 255
+    };
+}
+
 export function generateHexGrid() {
     state.hexes = [];
     const hexWidth = state.hexSize * Math.sqrt(3);
@@ -61,7 +74,8 @@ export function drawMap(ctx, canvas, ui) {
     ctx.drawImage(state.mapImage, 0, 0, state.mapImage.width, state.mapImage.height, 0, 0, scaledWidth, scaledHeight);
     ctx.strokeStyle = state.gridColor;
     ctx.lineWidth = state.gridThickness;
-    ctx.fillStyle = `${state.fogColor}${Math.round(state.fogOpacity * 255).toString(16).padStart(2, '0')}`;
+    const { r, g, b } = hexToRgb(state.fogColor);
+    ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${state.fogOpacity})`;
     for (const hex of state.hexes) {
         if (!hex.revealed) {
             drawHex(ctx, hex);

--- a/script.js
+++ b/script.js
@@ -77,12 +77,25 @@ document.addEventListener('DOMContentLoaded', function() {
     let gridColor = '#FFFFFF';
     let gridThickness = 1;
     let tokenColor = '#FF0000';
-    
+
     // New state variables for tokens
     let tokens = [];
     let isDraggingToken = false;
     let selectedTokenIndex = -1;
     let isAddingToken = false;
+
+    function hexToRgb(hex) {
+        hex = hex.replace('#', '');
+        if (hex.length === 3) {
+            hex = hex.split('').map(c => c + c).join('');
+        }
+        const num = parseInt(hex, 16);
+        return {
+            r: (num >> 16) & 255,
+            g: (num >> 8) & 255,
+            b: num & 255
+        };
+    }
     
     // Interaction mode - true for reveal, false for hide
     let revealMode = true;
@@ -623,7 +636,8 @@ document.addEventListener('DOMContentLoaded', function() {
         // Draw unrevealed hexes
         ctx.strokeStyle = gridColor;
         ctx.lineWidth = gridThickness;
-        ctx.fillStyle = `${fogColor}${Math.round(fogOpacity * 255).toString(16).padStart(2, '0')}`;
+        const { r, g, b } = hexToRgb(fogColor);
+        ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${fogOpacity})`;
         
         for (const hex of hexes) {
             if (!hex.revealed) {


### PR DESCRIPTION
## Summary
- compute fog fill color using rgba in both drawMap implementations
- parse hex fogColor strings to RGB

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6871e780ccf4832f9586f77ccc3114b6