### PR TITLE
Shift controls to sliding sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ HexPlora is a web-based viewer for tabletop-style maps. It overlays a hexagonal 
 - Add, move and clear tokens with selectable colors.
 - Zoom and pan support with mouse wheel and drag controls.
 - Import/export of the full map state (tokens, revealed hexes, settings).
-- Toggleable header and optional debug view.
+- Toggleable sidebar and optional debug view.
 
 ## Opening `index.html`
 
@@ -34,7 +34,7 @@ This project relies on standard HTML5 Canvas and modern JavaScript (ES6) feature
 
 ## Main Controls
 
-The top header contains controls for map settings and appearance:
+The left sidebar contains controls for map settings and appearance:
 
 - **Map URL** – enter an image URL and click **Load Map** to display it.
 - **Grid Settings** – configure hex size, grid offsets, column/row counts and map scale.
@@ -49,6 +49,6 @@ A row of buttons below the settings provides quick actions:
 - **Toggle Debug** – shows internal debug information.
 - **Export State** – opens a modal to copy or download the current state as JSON.
 - **Import State** – load a JSON file previously exported.
-- **Hide Header** – collapses the control panel to maximize map space.
+- **Hide Menu** – collapses the control panel to maximize map space.
 
 Status indicators at the bottom display the current zoom level and hovered hex. Pan with the middle or right mouse button and zoom with the scroll wheel.

--- a/events.js
+++ b/events.js
@@ -6,7 +6,7 @@ export function setupEventListeners(ui, handlers) {
         exportBtn,
         importFile,
         toggleModeBtn,
-        toggleHeaderBtn,
+        toggleSidebarBtn,
         resetViewBtn,
         addTokenBtn,
         clearTokensBtn,
@@ -42,7 +42,7 @@ export function setupEventListeners(ui, handlers) {
         drawMap,
         saveState,
         toggleMode,
-        toggleHeader,
+        toggleSidebar,
         resetMap,
         resetView,
         toggleAddTokenMode,
@@ -114,7 +114,7 @@ export function setupEventListeners(ui, handlers) {
     });
 
     toggleModeBtn.addEventListener('click', toggleMode);
-    toggleHeaderBtn.addEventListener('click', toggleHeader);
+    toggleSidebarBtn.addEventListener('click', toggleSidebar);
     resetBtn.addEventListener('click', resetMap);
     resetViewBtn.addEventListener('click', resetView);
     addTokenBtn.addEventListener('click', toggleAddTokenMode);

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 <!-- partial:index.partial.html -->
-<div class="header" id="header-content">
+<div class="sidebar" id="sidebar">
   <div class="title-bar">
     <h1>Pointy-Top Hex Map Viewer</h1>
     <div class="header-info">
@@ -94,8 +94,8 @@
   </div>
 </div>
 
-<div class="header-toggle">
-  <button id="toggle-header-btn" class="btn btn-primary">Hide Header</button>
+<div class="sidebar-toggle">
+  <button id="toggle-sidebar-btn" class="btn btn-primary">Hide Menu</button>
 </div>
 
 <div class="map-container" id="map-container">

--- a/script.js
+++ b/script.js
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const exportBtn = document.getElementById('export-btn');
     const importFile = document.getElementById('import-file');
     const toggleModeBtn = document.getElementById('toggle-mode-btn');
-    const toggleHeaderBtn = document.getElementById('toggle-header-btn');
+    const toggleSidebarBtn = document.getElementById('toggle-sidebar-btn');
     const resetViewBtn = document.getElementById('reset-view-btn');
     const addTokenBtn = document.getElementById('add-token-btn');
     const removeTokenBtn = document.getElementById('remove-token-btn');
@@ -245,8 +245,8 @@ document.addEventListener('DOMContentLoaded', function() {
         // Toggle mode button
         toggleModeBtn.addEventListener('click', toggleMode);
         
-        // Toggle header button
-        toggleHeaderBtn.addEventListener('click', toggleHeader);
+        // Toggle sidebar button
+        toggleSidebarBtn.addEventListener('click', toggleSidebar);
         
         resetBtn.addEventListener('click', resetMap);
         
@@ -1158,23 +1158,25 @@ document.addEventListener('DOMContentLoaded', function() {
         drawMap(); // Redraw to update any debug info
     }
     
-    // Toggle header panel
-    function toggleHeader() {
-        const headerContent = document.getElementById('header-content');
-        const isVisible = !headerContent.classList.contains('collapsed');
-        
-        // Toggle visibility
+    // Toggle sidebar panel
+    function toggleSidebar() {
+        const sidebar = document.getElementById('sidebar');
+        const isVisible = !sidebar.classList.contains('collapsed');
+
         if (isVisible) {
-            headerContent.classList.add('collapsed');
+            sidebar.classList.add('collapsed');
+            document.body.classList.add('sidebar-collapsed');
         } else {
-            headerContent.classList.remove('collapsed');
+            sidebar.classList.remove('collapsed');
+            document.body.classList.remove('sidebar-collapsed');
         }
-        
+
         // Update button text
-        toggleHeaderBtn.textContent = isVisible ? 'Show Header' : 'Hide Header';
-        
-        log(`Header ${isVisible ? 'hidden' : 'shown'}`);
-        showStatus(`Header ${isVisible ? 'hidden' : 'shown'}`, 'info');
+        toggleSidebarBtn.textContent = isVisible ? 'Show Menu' : 'Hide Menu';
+
+        log(`Sidebar ${isVisible ? 'hidden' : 'shown'}`);
+        showStatus(`Sidebar ${isVisible ? 'hidden' : 'shown'}`, 'info');
+        drawMap();
     }
     
     function updateInputFields() {

--- a/style.css
+++ b/style.css
@@ -11,23 +11,24 @@ body {
     overflow: hidden; /* Prevent body scrollbars */
 }
 
-/* Header Section */
-.header {
+/* Sidebar Section */
+.sidebar {
     background-color: #2d3748; /* Slightly lighter dark */
     padding: 0.75rem 1rem;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-    transition: max-height 0.4s ease-out, opacity 0.3s ease, padding 0.3s ease;
-    overflow: hidden;
-    max-height: 500px; /* Adjust as needed for content */
-    flex-shrink: 0; /* Prevent header from shrinking */
+    transition: transform 0.4s ease;
+    overflow-y: auto;
+    width: 300px;
+    flex-shrink: 0;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1000;
 }
 
-.header.collapsed {
-    max-height: 0;
-    padding-top: 0;
-    padding-bottom: 0;
-    opacity: 0;
-    border-bottom: none; /* Hide border when collapsed */
+.sidebar.collapsed {
+    transform: translateX(-100%);
 }
 
 .title-bar {
@@ -205,14 +206,14 @@ input[type="range"] {
     cursor: pointer;
 }
 
-/* Header Toggle Button */
-.header-toggle {
+/* Sidebar Toggle Button */
+.sidebar-toggle {
     position: fixed;
     top: 5px;
-    right: 5px;
-    z-index: 1050; /* Above header */
+    left: 5px;
+    z-index: 1050; /* Above sidebar */
 }
-.header-toggle .btn {
+.sidebar-toggle .btn {
      padding: 0.3rem 0.6rem;
      font-size: 0.75rem;
 }
@@ -220,7 +221,7 @@ input[type="range"] {
 
 /* Map Container */
 .map-container {
-    flex: 1; /* Take remaining vertical space */
+    flex: 1; /* Take remaining horizontal space */
     overflow: hidden; /* Crucial for pan/zoom */
     position: relative; /* For loading overlay */
     background-color: #1a202c; /* Ensure bg color */
@@ -228,6 +229,12 @@ input[type="range"] {
     user-select: none; /* Prevent text selection */
     -webkit-user-select: none; /* Safari */
     touch-action: none; /* Prevent browser default touch actions like scroll/zoom */
+    margin-left: 300px; /* space for sidebar */
+    transition: margin-left 0.4s ease;
+}
+
+body.sidebar-collapsed .map-container {
+    margin-left: 0;
 }
 
 .map-container.panning {


### PR DESCRIPTION
## Summary
- move header markup into a fixed left sidebar
- rename toggle button and logic for sidebar
- slide map container when sidebar collapses
- update documentation and unused events module

## Testing
- `node -v`
- `node -e "console.log('test run')"`


------
https://chatgpt.com/codex/tasks/task_e_6871f414dc60832fb806477ee45c7bac