### PR TITLE
Add labels to tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ HexPlora is a web-based viewer for tabletop-style maps. It overlays a hexagonal 
 - Adjustable grid (hex size, offsets, column/row count and scale).
 - Customizable appearance for fog of war and grid lines.
 - Reveal/hide mode for managing fog of war directly on the canvas.
-- Add, move and clear tokens with selectable colors.
+- Add, move and clear tokens with selectable colors and optional labels.
 - Zoom and pan support with mouse wheel and drag controls.
-- Import/export of the full map state (tokens, revealed hexes, settings).
+- Import/export of the full map state (tokens with labels, revealed hexes, settings).
 - Toggleable header and optional debug view.
 
 ## Opening `index.html`
@@ -43,7 +43,7 @@ The top header contains controls for map settings and appearance:
 A row of buttons below the settings provides quick actions:
 
 - **Mode: Reveal/Hide** – switches between revealing or hiding hexes.
-- **Add Token** – enables token placement. Existing tokens can be dragged or cleared.
+ - **Add Token** – enables token placement. You will be prompted for a label when placing a token. Existing tokens can be dragged or cleared.
 - **Reset View** – resets zoom and panning. **Reset Fog** hides all revealed hexes.
 - **Clear Tokens** – removes all tokens from the map.
 - **Toggle Debug** – shows internal debug information.

--- a/render.js
+++ b/render.js
@@ -107,6 +107,18 @@ export function drawMap(ctx, canvas, ui) {
             ctx.lineWidth = 1;
             ctx.stroke();
         }
+
+        if (token.label) {
+            ctx.font = '12px Arial';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'top';
+            ctx.fillStyle = 'white';
+            ctx.strokeStyle = 'black';
+            ctx.lineWidth = 2;
+            const textY = token.y + state.hexSize * 0.5;
+            ctx.strokeText(token.label, token.x, textY);
+            ctx.fillText(token.label, token.x, textY);
+        }
     }
     if (state.debugMode) {
         ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';

--- a/script.js
+++ b/script.js
@@ -154,7 +154,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 
                 // Load tokens
                 if (state.tokens) {
-                    tokens = state.tokens;
+                    tokens = state.tokens.map(t => ({
+                        x: t.x,
+                        y: t.y,
+                        color: t.color,
+                        label: t.label || ''
+                    }));
                 }
                 
                 log('Loaded saved state');
@@ -683,6 +688,18 @@ document.addEventListener('DOMContentLoaded', function() {
                 ctx.lineWidth = 1;
                 ctx.stroke();
             }
+
+            if (token.label) {
+                ctx.font = '12px Arial';
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'top';
+                ctx.fillStyle = 'white';
+                ctx.strokeStyle = 'black';
+                ctx.lineWidth = 2;
+                const textY = token.y + hexSize * 0.5;
+                ctx.strokeText(token.label, token.x, textY);
+                ctx.fillText(token.label, token.x, textY);
+            }
         }
         
         if (debugMode) {
@@ -1044,11 +1061,12 @@ document.addEventListener('DOMContentLoaded', function() {
         const worldX = (x - panX) / zoomLevel;
         const worldY = (y - panY) / zoomLevel;
         
-        // Create the token - no label needed
+        const label = prompt('Enter a label for this token (optional):', '') || '';
         const newToken = {
             x: worldX,
             y: worldY,
-            color: tokenColor
+            color: tokenColor,
+            label: label
         };
         
         // Add to tokens array
@@ -1282,7 +1300,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 
                 // Apply tokens if they exist
                 if (importData.tokens) {
-                    tokens = importData.tokens;
+                    tokens = importData.tokens.map(t => ({
+                        x: t.x,
+                        y: t.y,
+                        color: t.color,
+                        label: t.label || ''
+                    }));
                 }
                 
                 // If there's a map URL, load it

--- a/state.js
+++ b/state.js
@@ -63,7 +63,12 @@ export function loadSavedState(ui) {
             }
         }
         if (data.tokens) {
-            state.tokens = data.tokens;
+            state.tokens = data.tokens.map(t => ({
+                x: t.x,
+                y: t.y,
+                color: t.color,
+                label: t.label || ''
+            }));
         }
     } catch (err) {
         console.error('Error loading saved state:', err);


### PR DESCRIPTION
## Summary
- allow tokens to store an optional `label`
- prompt for the label when placing a token
- show token labels on the canvas
- persist labels in saved/imported state
- document token labels in README

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_68725fa9a4d4832fb40b1b22a59a913b