### PR TITLE
Add grid orientation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ HexPlora is a web-based viewer for tabletop-style maps. It overlays a hexagonal 
 
 ## Features
 
-- Load a map image from any URL and generate a pointy-top hex grid.
+- Load a map image from any URL and generate a hex grid with selectable
+  pointy-top or flat-top orientation.
 - Adjustable grid (hex size, offsets, column/row count and scale).
 - Customizable appearance for fog of war and grid lines.
 - Reveal/hide mode for managing fog of war directly on the canvas.
@@ -37,7 +38,8 @@ This project relies on standard HTML5 Canvas and modern JavaScript (ES6) feature
 The top header contains controls for map settings and appearance:
 
 - **Map URL** – enter an image URL and click **Load Map** to display it.
-- **Grid Settings** – configure hex size, grid offsets, column/row counts and map scale.
+- **Grid Settings** – configure hex size, grid offsets, column/row counts,
+  map scale and orientation.
 - **Appearance** – adjust fog color/opacity, grid color/thickness and token color.
 
 A row of buttons below the settings provides quick actions:

--- a/events.js
+++ b/events.js
@@ -17,6 +17,7 @@ export function setupEventListeners(ui, handlers) {
         offsetYInput,
         columnsInput,
         rowsInput,
+        orientationInput,
         mapScaleInput,
         fogColorInput,
         fogOpacityInput,
@@ -78,6 +79,12 @@ export function setupEventListeners(ui, handlers) {
     });
     rowsInput.addEventListener('change', function() {
         handlers.state.rowCount = validateInput(this, 1, 200, 15);
+        generateHexGrid();
+        drawMap();
+        saveState();
+    });
+    orientationInput.addEventListener('change', function() {
+        handlers.state.orientation = this.value;
         generateHexGrid();
         drawMap();
         saveState();

--- a/index.html
+++ b/index.html
@@ -48,6 +48,13 @@
         <input type="number" id="rows" min="1" max="200" value="15">
       </div>
       <div class="control-group">
+        <label for="orientation">Grid Orientation</label>
+        <select id="orientation" title="Choose pointy-top or flat-top grid">
+          <option value="pointy">Pointy-Top</option>
+          <option value="flat">Flat-Top</option>
+        </select>
+      </div>
+      <div class="control-group">
         <label for="map-scale">Map Scale (%)</label>
         <input type="number" id="map-scale" min="10" max="500" value="100" title="Visual scale of the map image itself">
       </div>

--- a/render.js
+++ b/render.js
@@ -15,17 +15,30 @@ function hexToRgb(hex) {
 
 export function generateHexGrid() {
     state.hexes = [];
-    const hexWidth = state.hexSize * Math.sqrt(3);
-    const hexHeight = state.hexSize * 2;
+    let hexWidth, hexHeight;
+    if (state.orientation === 'pointy') {
+        hexWidth = state.hexSize * Math.sqrt(3);
+        hexHeight = state.hexSize * 2;
+    } else {
+        hexWidth = state.hexSize * 2;
+        hexHeight = state.hexSize * Math.sqrt(3);
+    }
     for (let row = 0; row < state.rowCount; row++) {
         for (let col = 0; col < state.columnCount; col++) {
-            const x = col * hexWidth + (row % 2 === 1 ? hexWidth / 2 : 0) + state.offsetX;
-            const y = row * (hexHeight * 3 / 4) + state.offsetY;
+            let x, y;
+            if (state.orientation === 'pointy') {
+                x = col * hexWidth + (row % 2 === 1 ? hexWidth / 2 : 0) + state.offsetX;
+                y = row * (hexHeight * 3 / 4) + state.offsetY;
+            } else {
+                x = col * (hexWidth * 3 / 4) + state.offsetX;
+                y = row * hexHeight + (col % 2 === 1 ? hexHeight / 2 : 0) + state.offsetY;
+            }
             const hexId = `${col}-${row}`;
             const isRevealed = state.revealedHexes[hexId] === true;
             const vertices = [];
+            const startAngle = state.orientation === 'pointy' ? Math.PI / 2 : 0;
             for (let i = 0; i < 6; i++) {
-                const angle = (Math.PI / 3) * i + Math.PI / 2;
+                const angle = (Math.PI / 3) * i + startAngle;
                 const px = x + state.hexSize * Math.cos(angle);
                 const py = y + state.hexSize * Math.sin(angle);
                 vertices.push({ x: px, y: py });

--- a/state.js
+++ b/state.js
@@ -6,6 +6,7 @@ export const state = {
     offsetY: 0,
     columnCount: 20,
     rowCount: 15,
+    orientation: 'pointy',
     mapScale: 100,
     hexes: [],
     revealedHexes: {},
@@ -41,6 +42,7 @@ export function loadSavedState(ui) {
             state.offsetY = data.settings.offsetY || state.offsetY;
             state.columnCount = data.settings.columnCount || state.columnCount;
             state.rowCount = data.settings.rowCount || state.rowCount;
+            state.orientation = data.settings.orientation || state.orientation;
             state.mapScale = data.settings.mapScale || state.mapScale;
             state.fogColor = data.settings.fogColor || state.fogColor;
             state.fogOpacity = data.settings.fogOpacity || state.fogOpacity;
@@ -54,6 +56,7 @@ export function loadSavedState(ui) {
                 ui.offsetYInput.value = state.offsetY;
                 ui.columnsInput.value = state.columnCount;
                 ui.rowsInput.value = state.rowCount;
+                ui.orientationInput.value = state.orientation;
                 ui.mapScaleInput.value = state.mapScale;
                 ui.fogColorInput.value = state.fogColor;
                 ui.fogOpacityInput.value = state.fogOpacity;
@@ -95,6 +98,7 @@ export function saveState(ui) {
             offsetY: state.offsetY,
             columnCount: state.columnCount,
             rowCount: state.rowCount,
+            orientation: state.orientation,
             mapScale: state.mapScale,
             fogColor: state.fogColor,
             fogOpacity: state.fogOpacity,


### PR DESCRIPTION
## Summary
- add Grid Orientation dropdown in grid settings
- compute coordinates for pointy or flat hexes
- store orientation in saved state and exported JSON
- update README documentation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6872641b0680832fb78a63404589da3b