### PR TITLE
Use Bootstrap caret for header toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ A row of buttons below the settings provides quick actions:
 - **Toggle Debug** – shows internal debug information.
 - **Export State** – opens a modal to copy or download the current state as JSON.
 - **Import State** – load a JSON file previously exported.
-- **Hide Header** – collapses the control panel to maximize map space.
+- **Header Toggle** (caret icon) – collapses or expands the control panel.
 
 Status indicators at the bottom display the current zoom level and hovered hex. Pan with the middle or right mouse button and zoom with the scroll wheel.

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Hex Map Viewer</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
   <link rel="stylesheet" href="./style.css">
 
 </head>
@@ -104,7 +105,7 @@
 </div>
 
 <div class="header-toggle position-fixed top-0 end-0 m-2">
-  <button id="toggle-header-btn" class="btn btn-primary btn-sm">Hide Header</button>
+  <button id="toggle-header-btn" class="btn btn-primary btn-sm"><i class="bi bi-caret-up-fill"></i></button>
 </div>
 
 <div class="map-container" id="map-container">

--- a/script.js
+++ b/script.js
@@ -1296,8 +1296,10 @@ document.addEventListener('DOMContentLoaded', function() {
             headerContent.classList.remove('collapsed');
         }
         
-        // Update button text
-        toggleHeaderBtn.textContent = isVisible ? 'Show Header' : 'Hide Header';
+        // Update button icon
+        toggleHeaderBtn.innerHTML = isVisible ?
+            '<i class="bi bi-caret-down-fill"></i>' :
+            '<i class="bi bi-caret-up-fill"></i>';
         
         log(`Header ${isVisible ? 'hidden' : 'shown'}`);
         showStatus(`Header ${isVisible ? 'hidden' : 'shown'}`, 'info');


### PR DESCRIPTION
## Summary
- include Bootstrap icons
- use caret icon instead of text for header toggle button
- update README to mention the new header toggle button

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_687280625c9c832f8f5b906745a4f3bf